### PR TITLE
[cgc-1][asset_platforms] Adding new command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ reqwest = { version = "0.11.22", features = ["json"] }
 tokio = { version = "1.35.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_with = "3.4"
 url = "2.5.0"
 thiserror = "1.0"
 

--- a/src/api/asset_platforms.rs
+++ b/src/api/asset_platforms.rs
@@ -1,0 +1,88 @@
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::api::response::Response;
+use crate::api::transport::Transport;
+use crate::api::Method;
+
+use super::client::CoinGecko;
+
+pub enum AssetPlatformsListParts {
+    None,
+}
+
+impl<'b> AssetPlatformsListParts {
+    fn url(&self) -> &'static str {
+        match self {
+            AssetPlatformsListParts::None => "/asset_platforms",
+        }
+    }
+}
+
+pub struct AssetPlatformsList<'a, 'b> {
+    transport: &'a Transport,
+    parts: AssetPlatformsListParts,
+    filter: Option<&'b str>,
+}
+
+impl<'a, 'b> AssetPlatformsList<'a, 'b> {
+    pub fn new(transport: &'a Transport, parts: AssetPlatformsListParts) -> Self {
+        AssetPlatformsList {
+            transport,
+            parts,
+            filter: None,
+        }
+    }
+
+    pub fn filter(mut self, only_nft_support: bool) -> Self {
+        if only_nft_support {
+            self.filter = Some("nft")
+        };
+        self
+    }
+
+    pub async fn send(self) -> Result<Response> {
+        let path = self.parts.url();
+        let method = Method::Get;
+        let query_string = {
+            #[serde_with::skip_serializing_none]
+            #[derive(Serialize)]
+            struct QueryParams<'b> {
+                filter: Option<&'b str>,
+            }
+            let query_params = QueryParams {
+                filter: self.filter,
+            };
+            Some(query_params)
+        };
+        let response = self
+            .transport
+            .send(method, &path, query_string.as_ref())
+            .await?;
+        Ok(response)
+    }
+}
+
+pub struct AssetPlatforms<'a> {
+    transport: &'a Transport,
+}
+
+impl<'a> AssetPlatforms<'a> {
+    fn new(transport: &'a Transport) -> Self {
+        Self { transport }
+    }
+
+    fn transport(&self) -> &Transport {
+        self.transport
+    }
+
+    pub fn list(&self, parts: AssetPlatformsListParts) -> AssetPlatformsList {
+        AssetPlatformsList::new(self.transport(), parts)
+    }
+}
+
+impl CoinGecko {
+    pub fn asset_platforms(&self) -> AssetPlatforms {
+        AssetPlatforms::new(self.transport())
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,4 @@
+pub mod asset_platforms;
 pub mod client;
 pub mod error;
 pub mod ping;

--- a/src/api/ping.rs
+++ b/src/api/ping.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::api::response::Response;
 use crate::api::transport::Transport;
@@ -32,7 +32,17 @@ impl<'a> PingPing<'a> {
     pub async fn send(&self) -> Result<Response> {
         let path = self.parts.url();
         let method = Method::Get;
-        let response = self.transport.send(method, &path).await?;
+        let query_string = {
+            #[serde_with::skip_serializing_none]
+            #[derive(Serialize)]
+            struct QueryParams {}
+            let query_params = QueryParams {};
+            Some(query_params)
+        };
+        let response = self
+            .transport
+            .send(method, &path, query_string.as_ref())
+            .await?;
         Ok(response)
     }
 }

--- a/src/api/simple.rs
+++ b/src/api/simple.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::api::client::CoinGecko;
 use crate::api::response::Response;
@@ -31,7 +31,17 @@ impl<'a> SimpleSupportedVsCurrencies<'a> {
     pub async fn send(&self) -> Result<Response> {
         let path = self.parts.url();
         let method = Method::Get;
-        let response = self.transport.send(method, &path).await?;
+        let query_string = {
+            #[serde_with::skip_serializing_none]
+            #[derive(Serialize)]
+            struct QueryParams {}
+            let query_params = QueryParams {};
+            Some(query_params)
+        };
+        let response = self
+            .transport
+            .send(method, &path, query_string.as_ref())
+            .await?;
         Ok(response)
     }
 }

--- a/src/cli/asset_platforms.rs
+++ b/src/cli/asset_platforms.rs
@@ -1,0 +1,52 @@
+use crate::api::asset_platforms::AssetPlatformsListParts;
+use crate::api::client::CoinGecko;
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use serde_json::Value;
+
+#[derive(Parser)]
+pub struct AssetPlatformsCtx {
+    #[command(subcommand)]
+    commands: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// List all asset platforms (Blockchain networks)
+    List(ListCtx),
+}
+
+#[derive(Parser)]
+pub struct ListCtx {
+    /// List only platforms that support NFT
+    #[arg(long, default_value_t = false)]
+    only_nft_support: bool,
+}
+
+impl ListCtx {
+    pub async fn run_command(&self, client: &CoinGecko) -> Result<()> {
+        println!("List...");
+        let respoinse = client
+            .asset_platforms()
+            .list(AssetPlatformsListParts::None)
+            .filter(self.only_nft_support)
+            .send()
+            .await?;
+
+        let body: Value = respoinse.json().await?;
+        println!("{:#}", body);
+        Ok(())
+    }
+}
+
+impl AssetPlatformsCtx {
+    pub async fn run_command(&self, client: &CoinGecko) -> Result<()> {
+        println!("Asset Platforms...");
+        match &self.commands {
+            Commands::List(ctx) => {
+                ListCtx::run_command(ctx, client).await?;
+            }
+        };
+        Ok(())
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,2 +1,3 @@
+pub mod asset_platforms;
 pub mod ping;
 pub mod simple;

--- a/src/cli/ping.rs
+++ b/src/cli/ping.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use clap::Parser;
 use serde_json::Value;
 
-#[derive(Parser, Debug)]
+#[derive(Parser)]
 pub struct PingCtx {}
 
 impl PingCtx {

--- a/src/cli/simple.rs
+++ b/src/cli/simple.rs
@@ -4,13 +4,13 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use serde_json::Value;
 
-#[derive(Debug, Parser)]
+#[derive(Parser)]
 pub struct SimpleCtx {
     #[command(subcommand)]
     commands: Commands,
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Subcommand)]
 enum Commands {
     /// Get the current price of any cryptocurrencies in any other supported currencies that you need.
     Price(PriceCtx),
@@ -21,7 +21,7 @@ enum Commands {
     SupportedVsCurrencies(SupportedVsCurrenciesCtx),
 }
 
-#[derive(Debug, Parser)]
+#[derive(Parser)]
 pub struct SupportedVsCurrenciesCtx {}
 
 impl SupportedVsCurrenciesCtx {
@@ -40,7 +40,7 @@ impl SupportedVsCurrenciesCtx {
     }
 }
 
-#[derive(Debug, Parser)]
+#[derive(Parser)]
 pub struct PriceCtx {}
 
 impl PriceCtx {
@@ -49,7 +49,7 @@ impl PriceCtx {
     }
 }
 
-#[derive(Debug, Parser)]
+#[derive(Parser)]
 pub struct TokenPriceCtx {}
 
 impl TokenPriceCtx {
@@ -59,7 +59,7 @@ impl TokenPriceCtx {
 }
 
 impl SimpleCtx {
-    pub async fn run_command(&self, client: &CoinGecko) {
+    pub async fn run_command(&self, client: &CoinGecko) -> Result<()> {
         match &self.commands {
             Commands::SupportedVsCurrencies(ctx) => {
                 SupportedVsCurrenciesCtx::run_command(ctx, client).await;
@@ -71,5 +71,6 @@ impl SimpleCtx {
                 TokenPriceCtx::run_command(ctx).await;
             }
         };
+        Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod cli;
 
 // mod simple;
 use crate::api::transport::TransportBuilder;
+use crate::cli::asset_platforms::AssetPlatformsCtx;
 use crate::cli::ping::PingCtx;
 use crate::cli::simple::SimpleCtx;
 use anyhow::Result;
@@ -20,6 +21,7 @@ struct Crypto {
 
 #[derive(Subcommand)]
 enum Commands {
+    AssetPlatforms(AssetPlatformsCtx),
     Ping(PingCtx),
     Simple(SimpleCtx),
 }
@@ -35,7 +37,8 @@ async fn main() -> Result<()> {
 
     match &cli.commands {
         Commands::Ping(ctx) => PingCtx::run_command(ctx, &client).await?,
-        Commands::Simple(ctx) => SimpleCtx::run_command(ctx, &client).await,
-    }
+        Commands::Simple(ctx) => SimpleCtx::run_command(ctx, &client).await?,
+        Commands::AssetPlatforms(ctx) => AssetPlatformsCtx::run_command(ctx, &client).await?,
+    };
     Ok(())
 }


### PR DESCRIPTION
* I am adding the new command `asset_platforms` with has a subcommand to `list`  all asset platforms. This include the implementation for the command in the api module.
* I am adding support to pass query strings as part of the http request in th transport send method. This was required by the new command in order to filter only platform that support NFT