### PR TITLE
Add simple price command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://www.coingecko.com/en/api/documentation#
 | Command         | Status      |
 | --------------- | ----------- |
 | ping            | Done        |
-| simple          | In progress |
+| simple          | Done        |
 | coins           |             |
 | contract        |             |
 | asset_platforms | In progress |


### PR DESCRIPTION
## Summary
- implement new price subcommand under `simple`
- wire up API client for `/simple/price`
- mark `simple` as done in README

## Changes
- add `SimplePrice` API handler with options
- add CLI fields for price subcommand
- call new API methods from CLI

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684021a189b883259441948057570934